### PR TITLE
chore(name): update safe-network-app repo/package name to sn_app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ env:
   AWS_ACCESS_KEY_ID: AKIAVVODCRMSJ5MV63VB
   AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: eu-west-2
-  APPLICATION: safe-network-app
+  BUCKET: safe-network-app
+  APPLICATION: sn_app
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
   CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -164,7 +165,7 @@ jobs:
       # s3
       - name: Put all release files on s3
         shell: bash
-        run: aws s3 cp release/ s3://${{ env.APPLICATION }}/tag-builds/${{ env.RELEASE_VERSION }} --acl public-read --recursive
+        run: aws s3 cp release/ s3://${{ env.BUCKET }}/tag-builds/${{ env.RELEASE_VERSION }} --acl public-read --recursive
 
       - name: Release generation
         uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,4 +90,4 @@ jobs:
           run: yarn test-e2e-packed 
       - name: Check logs on fail
         if: failure()
-        run: cat ~/config/safe-network-app/logs/*.log
+        run: cat ~/config/sn_app/logs/*.log

--- a/.github/workflows/s3release.yml
+++ b/.github/workflows/s3release.yml
@@ -13,7 +13,8 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: eu-west-2
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      APPLICATION: safe-network-app
+      BUCKET: safe-network-app
+      APPLICATION: sn_app
     steps:
       - name: Set tag as env
         run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
@@ -35,7 +36,7 @@ jobs:
       # mac
       - name: Download build from s3 for this tag
         shell: bash
-        run: aws s3 cp s3://${{ env.APPLICATION }}/tag-builds/${{ env.RELEASE_VERSION }} . --recursive
+        run: aws s3 cp s3://${{ env.BUCKET }}/tag-builds/${{ env.RELEASE_VERSION }} . --recursive
 
       # do more...
       - name: Check dlded assets
@@ -47,51 +48,51 @@ jobs:
       # mac
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-mac-x64.dmg" s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-mac/ --acl public-read
+        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-mac-x64.dmg" s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-mac/ --acl public-read
 
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-mac-x64.dmg.blockmap" s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-mac/ --acl public-read
+        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-mac-x64.dmg.blockmap" s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-mac/ --acl public-read
 
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-mac-x64.zip" s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-mac/ --acl public-read
+        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-mac-x64.zip" s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-mac/ --acl public-read
 
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-mac-x64.pkg" s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-mac/ --acl public-read
+        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-mac-x64.pkg" s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-mac/ --acl public-read
 
       # linux
       - name: chmod
         run: chmod +x ${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-linux-x64.AppImage
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-linux-x64.zip" s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-linux/ --acl public-read
+        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-linux-x64.zip" s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-linux/ --acl public-read
 
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-linux-x64.AppImage" s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-linux/ --acl public-read
+        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-linux-x64.AppImage" s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-linux/ --acl public-read
 
       # win
 
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-win-x64.exe" s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-win/ --acl public-read
+        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-win-x64.exe" s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-win/ --acl public-read
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-win-x64.exe.blockmap" s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-win/ --acl public-read
+        run: aws s3 cp "${{ env.APPLICATION }}-${{ env.RELEASE_VERSION }}-win-x64.exe.blockmap" s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-win/ --acl public-read
 
       # YAMLS
 
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp ${{ env.YAML_FILE }}.yml s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-win/ --acl public-read
+        run: aws s3 cp ${{ env.YAML_FILE }}.yml s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-win/ --acl public-read
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp ${{ env.YAML_FILE }}-mac.yml s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-mac/ --acl public-read
+        run: aws s3 cp ${{ env.YAML_FILE }}-mac.yml s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-mac/ --acl public-read
       - name: Upload to s3
         shell: bash
-        run: aws s3 cp ${{ env.YAML_FILE }}-linux.yml s3://${{ env.APPLICATION }}/${{ env.APPLICATION }}-linux/ --acl public-read
+        run: aws s3 cp ${{ env.YAML_FILE }}-linux.yml s3://${{ env.BUCKET }}/${{ env.APPLICATION }}-linux/ --acl public-read
 
       # Update the release with artifacts
       - name: Release generation

--- a/.testcafe-electron-rc.js
+++ b/.testcafe-electron-rc.js
@@ -1,4 +1,4 @@
-let appString = 'safe-network-app';
+let appString = 'sn_app';
 
 let TEST_UNPACKED = process.env.TEST_UNPACKED;
 const pkg = require('./package.json');

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ script:
 after_failure:
 # check resolution...
 - system_profiler SPDisplaysDataType | grep Resolution
-- cat $TMPDIR/safe-network-app.log;
-- ls "/Users/travis/build/joshuef/safe-network-app/release/"
+- cat $TMPDIR/sn_app.log;
+- ls "/Users/travis/build/joshuef/sn_app/release/"
 - ls "release/mac/SAFE Network App.app"
 - ls "release/mac/SAFE Network App.app/Contents/Resources/"
 - ls "release/linux/resources"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# SAFE Network App
+# Safe Network App
 
-Desktop app for managing the your SAFE Network applications.
+Desktop app for managing the your Safe Network applications.
 
 |                                                                Linux/OS X                                                                 | Windows | Issues |                                                Lines of Code                                                 |
 | :---------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :----: | :----------------------------------------------------------------------------------------------------------: |
-| [![Build Status](https://travis-ci.com/maidsafe/safe_launchpad_app.svg?branch=master)](https://travis-ci.com/maidsafe/safe_launchpad_app) |         |        | [![LoC](https://tokei.rs/b1/github/maidsafe/safe-network-app)](https://github.com/maidsafe/safe-network-app) |
+| [![Build Status](https://travis-ci.com/maidsafe/safe_launchpad_app.svg?branch=master)](https://travis-ci.com/maidsafe/safe_launchpad_app) |         |        | [![LoC](https://tokei.rs/b1/github/maidsafe/sn_app)](https://github.com/maidsafe/sn_app) |
 
-| [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+| [MaidSafe website](https://maidsafe.net) | [Safe Dev Forum](https://forum.safedev.org) | [Safe Network Forum](https://safenetforum.org) |
 | :--------------------------------------: | :-----------------------------------------: | :--------------------------------------------: |
 
 ## Downloading
@@ -29,7 +29,7 @@ This will not write to the filesystem, but will log to the console what changes 
 
 ## Releases
 
--   Fork the SAFE Network App repository
+-   Fork the Safe Network App repository
 -   Clone repo locally or ensure the latest commit has been pulled if it is already cloned.
 -   Before running yarn commands, ensure you remove any local tags and pull all tags from master
 -   To install the dependencies run `yarn`.
@@ -40,7 +40,7 @@ This will not write to the filesystem, but will log to the console what changes 
 
 ## License
 
-This SAFE Network library is dual-licensed under the Modified BSD ([LICENSE-BSD](LICENSE-BSD) https://opensource.org/licenses/BSD-3-Clause) or the MIT license ([LICENSE-MIT](LICENSE-MIT) https://opensource.org/licenses/MIT) at your option.
+This Safe Network library is dual-licensed under the Modified BSD ([LICENSE-BSD](LICENSE-BSD) https://opensource.org/licenses/BSD-3-Clause) or the MIT license ([LICENSE-MIT](LICENSE-MIT) https://opensource.org/licenses/MIT) at your option.
 
 ## Contributing
 

--- a/app/actions/alias/app_manager_actions.ts
+++ b/app/actions/alias/app_manager_actions.ts
@@ -46,7 +46,7 @@ export const storeApplicationSkipVersion = ( application: App ) => mockPromise()
 
 const userAgentRequest = request.defaults( {
     headers: {
-        'User-Agent': 'safe-network-app'
+        'User-Agent': 'sn_app'
     }
 } );
 
@@ -142,7 +142,7 @@ const getLatestElectronAppVersions = async (): Promise<void> => {
 
             if ( RELEASE_CHANNEL === BETA ) channelModifier = 'beta';
 
-            // https://safe-network-app.s3.eu-west-2.amazonaws.com/safe-network-app-win/latest.yml
+            // https://safe-network-app.s3.eu-west-2.amazonaws.com/sn_app-win/latest.yml
             let latestVersionFile = `${s3Url}/${channelModifier}`;
 
             if ( isRunningOnMac ) latestVersionFile = `${latestVersionFile}-mac`;
@@ -197,7 +197,7 @@ const resumeDownloadOfApp = ( application ) => {
 
 export const updateTheApplication = ( application: App ) => {
     if ( application.name === 'SAFE Network App' ) {
-        ipcRenderer.send( 'update-safe-network-app', application );
+        ipcRenderer.send( 'update-sn_app', application );
 
         return;
     }
@@ -233,7 +233,7 @@ const pauseDownloadOfAllApps = ( appList: App ) => {
 
 const restartTheApplication = ( application: App ) => {
     if ( application.name === 'SAFE Network App' )
-        ipcRenderer.send( 'install-safe-network-app' );
+        ipcRenderer.send( 'install-sn_app' );
     else console.log( 'no app update feature available at the moment' );
 };
 

--- a/app/autoUpdate.ts
+++ b/app/autoUpdate.ts
@@ -63,7 +63,7 @@ autoUpdater.on( 'update-available', ( info ) => {
     }
 } );
 
-ipcMain.on( 'update-safe-network-app', ( event ) => {
+ipcMain.on( 'update-sn_app', ( event ) => {
     logger.info( 'Downloading SNAPP update.' );
     autoUpdater.downloadUpdate();
 } );
@@ -77,7 +77,7 @@ autoUpdater.on( 'update-downloaded', () => {
     );
 } );
 
-ipcMain.on( 'install-safe-network-app', ( event ) => {
+ipcMain.on( 'install-sn_app', ( event ) => {
     const appIsDownloading = checkIfAppIsDownloading();
     if ( appIsDownloading )
         store.subscribe( () => {

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 
 import pkg from '$Package';
 
-export const LOG_FILE_NAME = 'safe-network-app.log';
+export const LOG_FILE_NAME = 'sn_app.log';
 
 export const { platform } = process;
 export const MAC_OS = 'darwin';

--- a/app/menu.ts
+++ b/app/menu.ts
@@ -51,7 +51,7 @@ const subMenuHelp = {
             label: 'Documentation',
             click() {
                 shell.openExternal(
-                    'https://github.com/maidsafe/safe-network-app'
+                    'https://github.com/maidsafe/sn_app'
                 );
             }
         },
@@ -65,7 +65,7 @@ const subMenuHelp = {
             label: 'Search Issues',
             click() {
                 shell.openExternal(
-                    'https://github.com/maidsafe/safe-network-app/issues'
+                    'https://github.com/maidsafe/sn_app/issues'
                 );
             }
         },

--- a/builderConfig.js
+++ b/builderConfig.js
@@ -40,7 +40,7 @@ const buildConfig = {
     afterSign: './internals/scripts/afterSign.js',
     productName: getProductName(),
     generateUpdatesFilesForAllChannels: true,
-    appId: 'org.develar.SAFENetworkApp',
+    appId: 'org.develar.SafeNetworkApp',
     files: [
         './package.json',
         'app/dist',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "safe-network-app",
+  "name": "sn_app",
   "productName": "SAFE Network App",
   "version": "0.0.6-alpha",
   "identifier": "SAFE Network App",
@@ -19,7 +19,7 @@
     "lint-styles": "stylelint --ignore-path .eslintignore '**/*.*(css|scss)' --syntax scss",
     "lint-styles-fix": "yarn --silent lint-styles --fix; exit 0",
     "log-mac": "tail -f ~/Library/Logs/Safe\\ Network\\ App/*.log",
-    "log-linux": "tail -f ~/config/safe-network-app/logs/*.log",
+    "log-linux": "tail -f ~/config/sn_app/logs/*.log",
     "log-win": "Get-Content ~/%USERPROFILE%\\AppData\\Roaming\\SAFE\\ Network\\ App\\logs*.log -Wait -Tail 30",
     "package": "yarn build && electron-builder build --config ./builderConfig.js --publish never",
     "release": "yarn build && electron-builder build --config ./builderConfig.js --publish onTag",
@@ -66,7 +66,7 @@
   "main": "./app/main.prod.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/maidsafe/safe-network-app.git"
+    "url": "https://github.com/maidsafe/sn_app.git"
   },
   "author": {
     "name": "Josh Wilson",
@@ -75,7 +75,7 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/maidsafe/safe-network-app/issues"
+    "url": "https://github.com/maidsafe/sn_app/issues"
   },
   "keywords": [
     "SAFE",
@@ -86,7 +86,7 @@
     "sass",
     "webpack"
   ],
-  "homepage": "https://github.com/maidsafe/safe-network-app#readme",
+  "homepage": "https://github.com/maidsafe/sn_app#readme",
   "devDependencies": {
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",


### PR DESCRIPTION
Note that I decided to leave the S3 bucket as `safe-network-app` because `sn-app` was taken (also note you cannot have an `_` in a bucket name).

Added the `Next release` flag as merging this will trigger a new release, but it is not expected that a new release would be functional at this time so better to merge this once other work has been completed to make a new release compatible with latest vaults, cli, etc.